### PR TITLE
Backport PRs to prod

### DIFF
--- a/.github/workflows/pre-dev.yml
+++ b/.github/workflows/pre-dev.yml
@@ -9,3 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - run: echo "build"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,7 @@ queue_rules:
     conditions: []
 
 pull_request_rules:
-  - name: automerge
+  - name: automerge to dev
     conditions:
       - and:
         - "base=dev"
@@ -18,3 +18,8 @@ pull_request_rules:
           {{ body }}
 
           Pull Request: https://github.com/{{ repository_full_name }}/pull/{{ number }}
+      backport:
+        branches:
+          - prod
+        assignees:
+          - "{{ author }}"


### PR DESCRIPTION
This should configure mergify to create a backport PR once a commit lands on dev to promote to prod. Automerging for that PR isn't configured yet.